### PR TITLE
Fixes/nullable

### DIFF
--- a/SimpleJira.Fakes/SimpleJira.Fakes.csproj
+++ b/SimpleJira.Fakes/SimpleJira.Fakes.csproj
@@ -8,11 +8,11 @@
         <Authors>Ivan Medvedev, Pavel Strabykin</Authors>
         <Description>Provides InMemory and File implementations of SimpleJira.Interface.IJira.</Description>
         <Copyright>Copyright ©2021 Ivan Medvedev</Copyright>
-        <PackageProjectUrl>https://github.com/ivan816/simple-jira/</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/4thGradeDropout/simple-jira/</PackageProjectUrl>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-        <RepositoryUrl>https://github.com/ivan816/simple-jira/</RepositoryUrl>
+        <RepositoryUrl>https://github.com/4thGradeDropout/simple-jira/</RepositoryUrl>
         <PackageTags>jira linq inmemory mock</PackageTags>
-        <PackageVersion>1.0.4</PackageVersion>
+        <PackageVersion>1.0.8</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SimpleJira.Tests/Integration/MockJira.cs
+++ b/SimpleJira.Tests/Integration/MockJira.cs
@@ -159,12 +159,13 @@ namespace SimpleJira.Tests.Integration
             var reference = await jira.CreateIssueAsync(new JiraCustomIssue
             {
                 Summary = "Test issue",
-                IntValue = 256
+                IntValue = 256,
+                NullableIntValue = null,
             }, CancellationToken.None);
             var response = await jira.SelectIssuesAsync<JiraCustomIssue>(new JiraIssuesRequest
             {
                 Jql = $"KEY = {reference.Key}",
-                Fields = new[] {"project", "issueType", "summary", "customfield_43567"}
+                Fields = new[] {"project", "issueType", "summary", "customfield_43567", "customfield_43568"}
             });
 
             Assert.That(response.Issues.Length, Is.EqualTo(1));
@@ -175,6 +176,7 @@ namespace SimpleJira.Tests.Integration
             Assert.That(response.Issues[0].IssueType.Id, Is.EqualTo(TestMetadata.IssueType.Id));
             Assert.That(response.Issues[0].Summary, Is.EqualTo("Test issue"));
             Assert.That(response.Issues[0].IntValue, Is.EqualTo(256));
+            Assert.That(response.Issues[0].NullableIntValue, Is.Null);
         }
 
         [TestCase(JiraType.File)]
@@ -369,6 +371,13 @@ namespace SimpleJira.Tests.Integration
             {
                 get => CustomFields[43567].Get<int>();
                 set => CustomFields[43567].Set(value);
+            }
+
+            [JiraIssueProperty(43568)]
+            public int? NullableIntValue
+            {
+                get => CustomFields[43568].Get<int?>();
+                set => CustomFields[43568].Set(value);
             }
 
             private class Scope : IDefineScope<JiraCustomIssue>

--- a/SimpleJira/Interface/Issue/JiraIssueFields.cs
+++ b/SimpleJira/Interface/Issue/JiraIssueFields.cs
@@ -46,9 +46,9 @@ namespace SimpleJira.Interface.Issue
         public void SetProperty(string property, object value)
         {
             if (jObject.TryGetValue(property, out _))
-                jObject[property] = Json.ToToken(value);
+                jObject[property] = value == null ? null : Json.ToToken(value);
             else
-                jObject.TryAdd(property, Json.ToToken(value));
+                jObject.TryAdd(property, value == null ? null : Json.ToToken(value));
         }
 
         public string ToJson()

--- a/SimpleJira/SimpleJira.csproj
+++ b/SimpleJira/SimpleJira.csproj
@@ -8,11 +8,11 @@
         <Authors>Ivan Medvedev, Pavel Strabykin</Authors>
         <Description>Provides the simple way to call JIRA Rest API using LINQ provider.</Description>
         <Copyright>Copyright ©2021 Ivan Medvedev</Copyright>
-        <PackageProjectUrl>https://github.com/ivan816/simple-jira/</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/4thGradeDropout/simple-jira/</PackageProjectUrl>
         <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-        <RepositoryUrl>https://github.com/ivan816/simple-jira/</RepositoryUrl>
+        <RepositoryUrl>https://github.com/4thGradeDropout/simple-jira/</RepositoryUrl>
         <PackageTags>jira linq</PackageTags>
-        <PackageVersion>1.0.4</PackageVersion>
+        <PackageVersion>1.0.8</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
These changes fix the bug with a setter of a nullable field.

**Bug's description**

If you declare a nullable issue's field (see code block 1), you will not be able to set a null in the field (see code block 2).

```c#
public class CustomIssue: JiraIssue {

    /* constructors */

    [JiraIssueProperty(43568)]
    public int? NullableField
    {
        get => CustomFields[43568].Get<int?>();
        set => CustomFields[43568].Set(value);
    }
}
``` 

```c#
new CustomIssue {
    NullableField = null
};
````

**Exception details**
```
System.ArgumentNullException: Value cannot be null. (Parameter 'o')
   at Newtonsoft.Json.Utilities.ValidationUtils.ArgumentNotNull(Object value, String parameterName)
   at Newtonsoft.Json.Linq.JToken.FromObjectInternal(Object o, JsonSerializer jsonSerializer)
   at Newtonsoft.Json.Linq.JToken.FromObject(Object o, JsonSerializer jsonSerializer)
   at SimpleJira.Impl.Serialization.Json.ToToken(Object obj)
   at SimpleJira.Interface.Issue.JiraIssueFields.SetProperty(String property, Object value)
   at SimpleJira.Impl.Controllers.JiraIssueFieldsController.SetValue(String key, Object value)
   at SimpleJira.Interface.Issue.JiraCustomFieldValue.Set[TValue](TValue value)
```
